### PR TITLE
Feature/save ideas to local storage

### DIFF
--- a/src/idea.js
+++ b/src/idea.js
@@ -13,10 +13,12 @@ class Idea {
   }
 
   deleteFromStorage() {
-
+    localStorage.removeItem(this.id);
   }
 //should be able to update the idea's title, body, or starred state
   updateIdea() {
-
+    var storedStarredValue = this.star;
+    var retrieveStoredIdea = localStorage.getItem(this.id);
+    JSON.parse(retrieveStoredIdea);
   }
 }

--- a/src/idea.js
+++ b/src/idea.js
@@ -8,7 +8,8 @@ class Idea {
 
 //should only have one job which is to save the instance to storage
   saveToStorage() {
-
+    var locallyStoredIdea = this;
+    localStorage.setItem(this.id, JSON.stringify(locallyStoredIdea));
   }
 
   deleteFromStorage() {

--- a/src/main.js
+++ b/src/main.js
@@ -4,7 +4,10 @@ var saveButton = document.querySelector('.save-card');
 var titleInput = document.querySelector('#title');
 var bodyInput = document.querySelector('#body');
 var savedIdeasSection = document.querySelector(".idea-cards");
+var searchAllIdeas = document.querySelector('#search-button');
+var showStarredIdeasButton = document.querySelector('#show-starred');
 
+// saveButton.addEventListener('click', saveEachCardToLocalStorage);
 saveButton.addEventListener('click', displayCard);
 titleInput.addEventListener('keyup', enableSaveButton);
 bodyInput.addEventListener('keyup', enableSaveButton);
@@ -12,6 +15,11 @@ savedIdeasSection.addEventListener('click', runningMethodsOnCardButtons);
 // savedIdeasSection.addEventListener('mouseover', deleteImageActive);
 // savedIdeasSection.addEventListener('mouseleave', deleteImageActive);
 
+function saveEachCardToLocalStorage() {
+  for (var i = 0; i < ideas.length; i++) {
+    ideas[i].saveToStorage();
+  }
+};
 
 function runningMethodsOnCardButtons(event) {
   if (event.target.className === "delete") {
@@ -28,17 +36,6 @@ function toggleIconOnAndOff (on, off) {
   on.classList.toggle('hidden');
   off.classList.toggle('hidden');
 };
-
-// function deleteImageActive() {
-//   var deleteImage = document.querySelector(".delete");
-//   var deleteActive = document.querySelector(".delete-active");
-//     if (event.target.className === 'delete') {
-//       toggleIconOnAndOff(deleteImage, deleteActive);
-//     }
-//     else {
-//       toggleIconOnAndOff(deleteActive, deleteImage);
-//     }
-// };
 
 function favoriteCard() {
     if (event.target.className === 'star') {
@@ -75,12 +72,12 @@ function starOnAndOff () {
   }
 };
 
-
 function displayCard(event) {
   event.preventDefault();
   createCard();
   inputCardToHTML();
   clearInputFields();
+  saveEachCardToLocalStorage();
 };
 
 function createCard() {

--- a/src/main.js
+++ b/src/main.js
@@ -13,6 +13,7 @@ bodyInput.addEventListener('keyup', enableSaveButton);
 savedIdeasSection.addEventListener('click', runningMethodsOnCardButtons);
 window.addEventListener('load', retrieveIdeasFromLocalStorage);
 
+
 function retrieveIdeasFromLocalStorage() {
   var localIdea;
   var parsedLocalIdea;
@@ -22,9 +23,11 @@ function retrieveIdeasFromLocalStorage() {
     parsedLocalIdea = JSON.parse(localIdea);
     savedIdea = new Idea(parsedLocalIdea.title, parsedLocalIdea.body);
     savedIdea.id = parsedLocalIdea.id;
+    savedIdea.star = parsedLocalIdea.star;
     ideas.push(savedIdea);
   }
   inputCardToHTML();
+  persistFavoriteOnPageReload();
 }
 
 function runningMethodsOnCardButtons(event) {
@@ -55,7 +58,23 @@ function removeCard () {
   for (var i = 0; i < ideas.length; i++) {
     if (ideas[i].id == cardID) {
       ideas.splice(i, 1);
+      ideas[i].deleteFromStorage();
       inputCardToHTML();
+    }
+  }
+};
+
+function persistFavoriteOnPageReload () {
+  var favorite = document.querySelectorAll(".star");
+  var unfavorite = document.querySelectorAll(".star-active");
+  for (var i = 0; i < ideas.length; i++) {
+    if (ideas[i].star === true) {
+    favorite[i].classList.add('hidden');
+    unfavorite[i].classList.remove('hidden');
+     }
+    else if (ideas[i].star === false) {
+    unfavorite[i].classList.add('hidden');
+    favorite[i].classList.remove('hidden');
     }
   }
 };
@@ -67,10 +86,12 @@ function starOnAndOff () {
   for (var i = 0; i < ideas.length; i++) {
     if (ideas[i].id == cardID && ideas[i].star === false) {
       ideas[i].star = true;
+      ideas[i].saveToStorage();
       toggleIconOnAndOff(favorite[i], unfavorite[i]);
     }
     else if (ideas[i].id == cardID && ideas[i].star === true) {
       ideas[i].star = false;
+      ideas[i].saveToStorage();
       toggleIconOnAndOff(unfavorite[i], favorite[i]);
     }
   }
@@ -80,6 +101,7 @@ function displayCard(event) {
   event.preventDefault();
   createCard();
   inputCardToHTML();
+  persistFavoriteOnPageReload();
   clearInputFields();
 };
 

--- a/src/main.js
+++ b/src/main.js
@@ -7,19 +7,24 @@ var savedIdeasSection = document.querySelector(".idea-cards");
 var searchAllIdeas = document.querySelector('#search-button');
 var showStarredIdeasButton = document.querySelector('#show-starred');
 
-// saveButton.addEventListener('click', saveEachCardToLocalStorage);
 saveButton.addEventListener('click', displayCard);
 titleInput.addEventListener('keyup', enableSaveButton);
 bodyInput.addEventListener('keyup', enableSaveButton);
 savedIdeasSection.addEventListener('click', runningMethodsOnCardButtons);
-// savedIdeasSection.addEventListener('mouseover', deleteImageActive);
-// savedIdeasSection.addEventListener('mouseleave', deleteImageActive);
+window.addEventListener('load', retrieveIdeasFromLocalStorage);
 
-function saveEachCardToLocalStorage() {
-  for (var i = 0; i < ideas.length; i++) {
-    ideas[i].saveToStorage();
+function retrieveIdeasFromLocalStorage() {
+  var localIdea;
+  var parsedLocalIdea;
+  var savedIdea;
+  for (var i = 0; i < localStorage.length; i++)  {
+    localIdea = localStorage.getItem(localStorage.key(i));
+    parsedLocalIdea = JSON.parse(localIdea);
+    savedIdea = new Idea(parsedLocalIdea.title, parsedLocalIdea.body);
+    ideas.push(savedIdea);
   }
-};
+  inputCardToHTML();
+}
 
 function runningMethodsOnCardButtons(event) {
   if (event.target.className === "delete") {
@@ -29,8 +34,6 @@ function runningMethodsOnCardButtons(event) {
     favoriteCard();
   }
 };
-
-
 
 function toggleIconOnAndOff (on, off) {
   on.classList.toggle('hidden');
@@ -77,12 +80,12 @@ function displayCard(event) {
   createCard();
   inputCardToHTML();
   clearInputFields();
-  saveEachCardToLocalStorage();
 };
 
 function createCard() {
   var ideaCard = new Idea(titleInput.value, bodyInput.value);
   ideas.push(ideaCard);
+  ideaCard.saveToStorage();
 };
 
 function clearInputFields() {

--- a/src/main.js
+++ b/src/main.js
@@ -21,6 +21,7 @@ function retrieveIdeasFromLocalStorage() {
     localIdea = localStorage.getItem(localStorage.key(i));
     parsedLocalIdea = JSON.parse(localIdea);
     savedIdea = new Idea(parsedLocalIdea.title, parsedLocalIdea.body);
+    savedIdea.id = parsedLocalIdea.id;
     ideas.push(savedIdea);
   }
   inputCardToHTML();


### PR DESCRIPTION
 ### What does this PR do? 
- Adds functionality for the following:
- Cards persist on page reload.
- Deleted cards are also removed from local storage so deleted cards do not reappear on page reload.
- The star icon will persist on page reload if it has been "favorited".
- Local storage will continuously be updated to reflect the status of our idea cards.

### What does it fix? 
- It doesn't fix any bugs, but it adds features.

### Is this a feature or a fix?
- This is a feature, or rather a few features.

### Where should the reviewer start? 
- Start by creating cards, clicking favorite star on and/or deleting cards, then refreshing the page.

### How should this be tested? 
- Use the console in dev tools to check the length of local storage and ideas array,  as well as the values (specifically of the star property) to ensure they match with the idea cards themselves.
