### PR TITLE
Feature/filtering starred ideas

### DIFF
--- a/src/idea.js
+++ b/src/idea.js
@@ -17,8 +17,6 @@ class Idea {
   }
 //should be able to update the idea's title, body, or starred state
   updateIdea() {
-    var storedStarredValue = this.star;
-    var retrieveStoredIdea = localStorage.getItem(this.id);
-    JSON.parse(retrieveStoredIdea);
+
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,7 @@ var titleInput = document.querySelector('#title');
 var bodyInput = document.querySelector('#body');
 var savedIdeasSection = document.querySelector(".idea-cards");
 var showStarredIdeasButton = document.querySelector('.show-starred');
+var searchBar = document.querySelector('#search');
 
 saveButton.addEventListener('click', displayCard);
 titleInput.addEventListener('keyup', enableSaveButton);
@@ -12,6 +13,18 @@ bodyInput.addEventListener('keyup', enableSaveButton);
 savedIdeasSection.addEventListener('click', runningMethodsOnCardButtons);
 window.addEventListener('load', retrieveIdeasFromLocalStorage);
 showStarredIdeasButton.addEventListener('click', filterStarredIdeas);
+searchBar.addEventListener('keyup', searchIdeas);
+
+function searchIdeas() {
+  var cardsToBeHidden = document.querySelectorAll('.card');
+  for (var i = 0; i < ideas.length; i++) {
+    if (ideas[i].title.includes(searchBar.value) || ideas[i].body.includes(searchBar.value)) {
+      cardsToBeHidden[i].classList.remove('hidden');
+    } else if (!ideas[i].title.includes(searchBar.value) || !ideas[i].body.includes(searchBar.value)) {
+        cardsToBeHidden[i].classList.add('hidden');
+    }
+  }
+};
 
 function filterStarredIdeas() {
   if (showStarredIdeasButton.innerText == "Show Starred Ideas") {
@@ -22,7 +35,7 @@ function filterStarredIdeas() {
     showStarredIdeasButton.innerHTML = `<strong>Show Starred Ideas</strong>`;
     showAllCards();
   }
-}
+};
 
 function showStarredCards() {
   var ideaCardArticle = document.querySelectorAll(".card");
@@ -31,7 +44,7 @@ function showStarredCards() {
       ideaCardArticle[i].classList.add('hidden');
     }
   }
-}
+};
 
 function showAllCards() {
   var ideaCardArticle = document.querySelectorAll(".card");
@@ -40,7 +53,7 @@ function showAllCards() {
       ideaCardArticle[i].classList.remove('hidden');
     }
   }
-}
+};
 
 
 function retrieveIdeasFromLocalStorage() {
@@ -57,7 +70,7 @@ function retrieveIdeasFromLocalStorage() {
   }
   inputCardToHTML();
   persistFavoriteOnPageReload();
-}
+};
 
 function runningMethodsOnCardButtons(event) {
   if (event.target.className === "delete") {
@@ -86,9 +99,10 @@ function removeCard() {
   var cardID = event.target.parentElement.id;
   for (var i = 0; i < ideas.length; i++) {
     if (ideas[i].id == cardID) {
-      ideas.splice(i, 1);
       ideas[i].deleteFromStorage();
+      ideas.splice(i, 1);
       inputCardToHTML();
+      persistFavoriteOnPageReload();
     }
   }
 };

--- a/src/main.js
+++ b/src/main.js
@@ -4,14 +4,43 @@ var saveButton = document.querySelector('.save-card');
 var titleInput = document.querySelector('#title');
 var bodyInput = document.querySelector('#body');
 var savedIdeasSection = document.querySelector(".idea-cards");
-var searchAllIdeas = document.querySelector('#search-button');
-var showStarredIdeasButton = document.querySelector('#show-starred');
+var showStarredIdeasButton = document.querySelector('.show-starred');
 
 saveButton.addEventListener('click', displayCard);
 titleInput.addEventListener('keyup', enableSaveButton);
 bodyInput.addEventListener('keyup', enableSaveButton);
 savedIdeasSection.addEventListener('click', runningMethodsOnCardButtons);
 window.addEventListener('load', retrieveIdeasFromLocalStorage);
+showStarredIdeasButton.addEventListener('click', filterStarredIdeas);
+
+function filterStarredIdeas() {
+  if (showStarredIdeasButton.innerText == "Show Starred Ideas") {
+    showStarredIdeasButton.innerHTML = `<strong>Show All Ideas</strong>`;
+    showStarredCards();
+  }
+  else if (showStarredIdeasButton.innerText == "Show All Ideas") {
+    showStarredIdeasButton.innerHTML = `<strong>Show Starred Ideas</strong>`;
+    showAllCards();
+  }
+}
+
+function showStarredCards() {
+  var ideaCardArticle = document.querySelectorAll(".card");
+  for (var i = 0; i < ideas.length; i++) {
+    if (ideas[i].star === false) {
+      ideaCardArticle[i].classList.add('hidden');
+    }
+  }
+}
+
+function showAllCards() {
+  var ideaCardArticle = document.querySelectorAll(".card");
+  for (var i = 0; i < ideas.length; i++) {
+    if (ideas[i].star === false) {
+      ideaCardArticle[i].classList.remove('hidden');
+    }
+  }
+}
 
 
 function retrieveIdeasFromLocalStorage() {
@@ -39,7 +68,7 @@ function runningMethodsOnCardButtons(event) {
   }
 };
 
-function toggleIconOnAndOff (on, off) {
+function toggleIconOnAndOff(on, off) {
   on.classList.toggle('hidden');
   off.classList.toggle('hidden');
 };
@@ -53,7 +82,7 @@ function favoriteCard() {
     }
 };
 
-function removeCard () {
+function removeCard() {
   var cardID = event.target.parentElement.id;
   for (var i = 0; i < ideas.length; i++) {
     if (ideas[i].id == cardID) {
@@ -64,22 +93,22 @@ function removeCard () {
   }
 };
 
-function persistFavoriteOnPageReload () {
+function persistFavoriteOnPageReload() {
   var favorite = document.querySelectorAll(".star");
   var unfavorite = document.querySelectorAll(".star-active");
   for (var i = 0; i < ideas.length; i++) {
     if (ideas[i].star === true) {
-    favorite[i].classList.add('hidden');
-    unfavorite[i].classList.remove('hidden');
-     }
+      favorite[i].classList.add('hidden');
+      unfavorite[i].classList.remove('hidden');
+    }
     else if (ideas[i].star === false) {
-    unfavorite[i].classList.add('hidden');
-    favorite[i].classList.remove('hidden');
+      unfavorite[i].classList.add('hidden');
+      favorite[i].classList.remove('hidden');
     }
   }
 };
 
-function starOnAndOff () {
+function starOnAndOff() {
   var favorite = document.querySelectorAll(".star");
   var unfavorite = document.querySelectorAll(".star-active");
   var cardID = event.target.parentElement.id;

--- a/styles.css
+++ b/styles.css
@@ -161,8 +161,9 @@ h3 {
   display: flex;
   border-color: black;
   height: 100%;
-  width: 20%;
+  width: 10%;
   background-image: url(assets/delete.svg);
+  background-repeat: no-repeat;
 }
 
 .delete:hover {


### PR DESCRIPTION
### What does this PR do?
Adds functionality to the Show Starred Ideas button which filters the idea cards displayed on the page. Also adds functionality to the search bar by enabling the search ideas input to filter through the idea cards.

 ### What does it fix?
This doesn't fix anything, but adds more features.

 ### Is this a feature or a fix?
It's a feature.

 ### Where should the reviewer start? 
The reviewer should start by creating a few cards, favoriting a couple, and clicking the Show Starred Ideas button. The user can also type inside the search bar to filter the cards displayed on the page.

### How should this be tested?
The user should only see idea cards that have been favorited with a red star when they click the Show Starred Ideas button. They should also only see cards with the letter or phrase typed in the search bar.